### PR TITLE
Upgrade to 1.0 action.yml syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM python:3.7-alpine
 
-LABEL "com.github.actions.name"="Python Syntax Checker"
-LABEL "com.github.actions.description"="Run flake8 to find syntax errors in a Python repo."
-LABEL "com.github.actions.icon"="upload-cloud"
-LABEL "com.github.actions.color"="6f42c1"
-
 RUN pip install --upgrade pip
 RUN pip install flake8
 RUN python --version ; pip --version ; echo "flake8 $(flake8 --version)" ; echo "===================="

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 A GitHub Action that runs selected [flake8](http://flake8.pycqa.org) tests on the Python code in your repo.
 If there are ___syntax errors or undefined names___ found in your Python code then this Action will fail.
 
-Example workflow (Put the following text into `.github/main.workflow`):
-```
-workflow "on push" {
-  on = "push"
-  resolves = ["Python Syntax Checker"]
-}
-
-action "Python Syntax Checker" {
-  uses = "cclauss/Find-Python-syntax-errors-action@master"
-}
+Example workflow (Put the following text into `.github/workflows/main.yml`):
+```yaml
+on: push
+name: Lint Python
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cclauss/Find-Python-syntax-errors-action@master
 ```
 ## Flake8 finds Python 3 syntax errors and undefined names
 $ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,8 @@
+name: "Python Syntax Checker"
+description: "Run flake8 to find syntax errors in a Python repo"
+runs:
+  using: "docker"
+  image: "Dockerfile"
+branding:
+  icon: upload-cloud
+  color: purple


### PR DESCRIPTION
This PR upgrades the documentation to use the YAML syntax and moves the metadata from the Dockerfile over to the [action.yml](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions) file. Tested it in a test repo and it works with the 1.0 of Actions.